### PR TITLE
Исправление integrity violation в ref_link при импорте

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,28 @@ php -S 127.0.0.1:9001 -t public dev-server.php
 
 2) Импортировать треды 25, 79-95 из архивача:
 - `./bin/console import-threads --source=arhivach`
+
+## Вызов команд Доктрины
+
+Для вызова команд Доктрины можно запускать утилиты `doctrine` и `doctrine-migrations`. Чтобы увидеть список доступных команд, запустите их с опцией `list`:
+
+```sh
+vendor/bin/doctrine-migrations list
+vendor/bin/doctrine list
+```
+
+Чтобы увидеть справку по команде, запустите её c опцией `--help` (например: `./vendor/bin/doctrine orm:validate-schema --help`).
+
+## Создание миграций
+
+Как правило, миграции (изменения в схеме БД) генерируются на основе изменений в файлах сущностей (в папке [src/Entity](src/Entity)). Чтобы изменить что-то в БД, отредактируйте аннотации в сущностях, затем запустите утилиту Доктрины для генерации миграций: 
+
+```sh
+vendor/bin/doctrine-migrations migrations:diff --formatted
+```
+
+Она сгенерирует новый файл миграции. Чтобы выполнить её, снова запустите утилиту Доктрины:
+
+```sh
+vendor/bin/doctrine-migrations migrations:migrate
+```

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
         "monolog/monolog": "^1.23",
         "foolz/sphinxql-query-builder": "^2.0",
         "ext-dom": "*",
-        "ext-libxml": "*"
+        "ext-libxml": "*",
+        "ext-mbstring": "*",
+        "ext-PDO_mysql": "*",
+        "jdorn/sql-formatter": "^1.2"
     },
     "require-dev": {
         "mikey179/vfsStream": "^1.6",

--- a/migrations/Version20200301111237.php
+++ b/migrations/Version20200301111237.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200301111237 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ref_link DROP FOREIGN KEY FK_21DFD8761645DEA9');
+        $this->addSql('ALTER TABLE ref_link CHANGE reference_id reference_id INT NOT NULL');
+        $this->addSql('ALTER TABLE 
+          ref_link 
+        ADD 
+          CONSTRAINT FK_21DFD8761645DEA9 FOREIGN KEY (reference_id) REFERENCES post (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ref_link DROP FOREIGN KEY FK_21DFD8761645DEA9');
+        $this->addSql('ALTER TABLE ref_link CHANGE reference_id reference_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE 
+          ref_link 
+        ADD 
+          CONSTRAINT FK_21DFD8761645DEA9 FOREIGN KEY (reference_id) REFERENCES post (id)');
+    }
+}

--- a/src/BoardClient/ArhivachClient.php
+++ b/src/BoardClient/ArhivachClient.php
@@ -28,11 +28,49 @@ class ArhivachClient
      */
     public function getPhpThreads(array $threadUrls = []): array
     {
-        return array_map(function ($threadUrl) {
-            $threadHtml = (string) $this->guzzle->get($threadUrl)->getBody();
+        $htmls = $this->downloadThreads($threadUrls);
+        $threads = [];
+        foreach ($htmls as $html) {
+            $threads[] = $this->threadParser->extractThread($html);
+        }
 
-            return $this->threadParser->extractThread($threadHtml);
-        }, $threadUrls);
+        return $threads;
+    }
+
+    /**
+     * Returns an array [thread id => thread HTML]
+     */
+    public function downloadThreads(array $urls): array
+    {
+        $htmls = [];
+        foreach ($urls as $url) {
+            $threadId = $this->getThreadIdFromUrl($url);
+            if (array_key_exists($threadId, $htmls)) {
+                throw new \LogicException("Thread key $threadId is not unique");
+            }
+
+            $htmls[$threadId] = (string) $this->guzzle->get($url)->getBody();
+        }
+
+        return $htmls;
+    }
+
+    public function getThreadIdFromUrl(string $url): string 
+    {
+        // E.g. /threads/12345.html
+        $path = parse_url($url, PHP_URL_PATH);
+        // Remove directories. Don't use pathinfo as it is platform-dependent
+        $path = preg_replace("!^(.*/)?([^/]+)/?$!u", '$2', $path);
+        // Remove extension
+        $path = preg_replace("!\.\w+$!u", '', $path);
+        // Replace unsafe characters
+        $path = preg_replace("![^a-zA-Z0-9_.,\-]+!u", '_', $path);
+
+        if ($path === '') {
+            throw new LogicException("Cannot generate safe thread name from URL $url");
+        }
+
+        return $path;
     }
 
     public function generateArchiveLink(): string

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -116,6 +116,11 @@ class Post
         }
     }
 
+    public function removeAllFiles(): void 
+    {
+        $this->files->clear();
+    }
+
     public function setTitle(string $title): self
     {
         $this->title = $title;

--- a/src/Entity/RefLink.php
+++ b/src/Entity/RefLink.php
@@ -18,7 +18,10 @@ class RefLink
      */
     private Post $post;
 
-    /** @ManyToOne(targetEntity="Post") */
+    /** 
+     * @ManyToOne(targetEntity="Post")
+     * @JoinColumn(nullable=false, onDelete="CASCADE")
+     */
     private Post $reference;
 
     /** @Column(type="integer") **/

--- a/src/FileStorage/LocalFileStorage.php
+++ b/src/FileStorage/LocalFileStorage.php
@@ -4,25 +4,34 @@ declare(strict_types=1);
 
 namespace phpClub\FileStorage;
 
+use GuzzleHttp\Client;
 use Symfony\Component\Filesystem\Filesystem;
 
 class LocalFileStorage implements FileStorageInterface
 {
     private Filesystem $filesystem;
+    private Client $guzzle;
     private string $uploadRoot;
 
-    public function __construct(Filesystem $filesystem, string $uploadRoot)
+    public function __construct(Filesystem $filesystem, Client $guzzle, string $uploadRoot)
     {
         $this->filesystem = $filesystem;
+        $this->guzzle = $guzzle;
         $this->uploadRoot = $uploadRoot;
     }
 
     public function put(string $path, string $directory): string
     {
         $relativePath = sprintf("/%s/%s", $directory, basename($path));
+        $targetPath = $this->uploadRoot . $relativePath;
 
         if (!$this->isFileExist($path, $directory)) {
-            $this->filesystem->copy($path, $this->uploadRoot . $relativePath);
+            if ($this->doesLookLikeUrl($path)) {
+                $content = $this->guzzle->get($path)->getBody();
+                $this->filesystem->dumpFile($targetPath, $content);
+            } else {
+                $this->filesystem->copy($path, $targetPath);
+            }
         }
 
         return $relativePath;
@@ -36,5 +45,10 @@ class LocalFileStorage implements FileStorageInterface
     public function getFileSize(string $path): int
     {
         return (int) (filesize($this->uploadRoot . $path) / 1_024);
+    }
+
+    private function doesLookLikeUrl(string $path): bool 
+    {
+        return preg_match("!^[a-z0-9_\-]://!ui", $path) > 0;
     }
 }

--- a/src/ThreadImport/ThreadImporter.php
+++ b/src/ThreadImport/ThreadImporter.php
@@ -10,6 +10,7 @@ use phpClub\Entity\File;
 use phpClub\Entity\Thread;
 use phpClub\FileStorage\FileStorageInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
+use Psr\Log\LoggerInterface;
 
 class ThreadImporter
 {
@@ -17,26 +18,37 @@ class ThreadImporter
     private EntityManagerInterface $entityManager;
     private LastPostUpdater $lastPostUpdater;
     private ChainManager $chainManager;
+    private LoggerInterface $logger;
 
     public function __construct(
         FileStorageInterface $fileStorage,
         EntityManagerInterface $entityManager,
         LastPostUpdater $lastPostUpdater,
-        ChainManager $chainManager
+        ChainManager $chainManager,
+        LoggerInterface $logger
     ) {
         $this->fileStorage = $fileStorage;
         $this->entityManager = $entityManager;
         $this->lastPostUpdater = $lastPostUpdater;
         $this->chainManager = $chainManager;
+        $this->logger = $logger;
     }
 
-    public function import(array $threads, callable $onThreadImported = null): void
-    {
+    public function import(
+        array $threads, 
+        callable $onThreadImported = null,
+        bool $deleteImages = false
+    ): void {
         $this->entityManager->beginTransaction();
         $this->cascadeRemoveThreads($threads);
 
         foreach ($threads as $thread) {
-            $this->saveFilesFromThread($thread);
+            if ($deleteImages) {
+                $this->deleteFilesFromThread($thread);
+            } else {
+                $this->saveFilesFromThread($thread);    
+            }
+            
             $this->entityManager->persist($thread);
             $this->chainManager->insertChain($thread);
             if ($onThreadImported) {
@@ -65,6 +77,13 @@ class ThreadImporter
         );
     }
 
+    private function deleteFilesFromThread(Thread $thread): void
+    {
+        foreach ($thread->getPosts() as $post) {
+            $post->removeAllFiles();
+        }
+    }
+
     private function saveFilesFromThread(Thread $thread): void
     {
         foreach ($thread->getPosts() as $post) {
@@ -77,6 +96,11 @@ class ThreadImporter
                     $this->updateFileSize($file);
                 } catch (IOException $e) {
                     // Unable to download, skip
+                    $this->logger->warn(sprintf(
+                        "Error saving image %s: %s",
+                        $file->getPath(),
+                        $e->getMessage()
+                    ));
                 }
             }
         }

--- a/src/ThreadParser/AbstractThreadParser.php
+++ b/src/ThreadParser/AbstractThreadParser.php
@@ -18,8 +18,11 @@ abstract class AbstractThreadParser
     protected MarkupConverter $markupConverter;
     private CloudflareEmailDecoder $cloudflareEmailDecoder;
 
-    public function __construct(DateConverter $dateConverter, MarkupConverter $markupConverter, CloudflareEmailDecoder $cloudflareEmailDecoder)
-    {
+    public function __construct(
+        DateConverter $dateConverter, 
+        MarkupConverter $markupConverter, 
+        CloudflareEmailDecoder $cloudflareEmailDecoder
+    ) {
         $this->markupConverter = $markupConverter;
         $this->dateConverter = $dateConverter;
         $this->cloudflareEmailDecoder = $cloudflareEmailDecoder;

--- a/src/ThreadParser/ArhivachThreadParser.php
+++ b/src/ThreadParser/ArhivachThreadParser.php
@@ -13,7 +13,11 @@ class ArhivachThreadParser extends AbstractThreadParser
 {
     protected function getPostsXPath(): string
     {
-        return '//div[@class="post"]';
+        /* 
+            Skip ads: 
+            <div class="post" id="M521122ScriptRootC785766"><div id="M521122PreloadC785766">Loading...</div></div>
+        */
+        return '//div[@class="post" and not(contains(@id, "ScriptRoot") and contains(./div/@id, "Preload"))]';
     }
 
     protected function getAuthorXPath(): string

--- a/src/Util/ConsoleUtil.php
+++ b/src/Util/ConsoleUtil.php
@@ -1,0 +1,21 @@
+<?php 
+
+declare(strict_types=1);
+
+namespace phpClub\Util;
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+class ConsoleUtil
+{
+	/**
+	 * Adds a handler that prints log messages to stderr. 
+	 *
+	 * @param int $minLevel Dump messages with this or higher level
+	 */
+	public static function copyLogToConsole(Logger $monolog, int $minLevel = Logger::WARNING)
+	{
+		$monolog->pushHandler(new StreamHandler('php://stderr', $minLevel));
+	}
+}

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Tests;
 
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Slim\Container;
+use Tests\FileStorage\FileStorageMock;
 use phpClub\Entity\File;
 use phpClub\Entity\Post;
 use phpClub\Entity\Thread;
@@ -13,9 +17,6 @@ use phpClub\ThreadImport\LastPostUpdater;
 use phpClub\ThreadImport\ThreadImporter;
 use phpClub\ThreadParser\DvachThreadParser;
 use phpClub\Util\FsUtil;
-use PHPUnit\Framework\TestCase;
-use Slim\Container;
-use Tests\FileStorage\FileStorageMock;
 
 abstract class AbstractTestCase extends TestCase
 {
@@ -49,7 +50,7 @@ abstract class AbstractTestCase extends TestCase
     public function getContainer(): Container
     {
         if (!self::$container) {
-            self::$container = require_once __DIR__ . '/../src/Bootstrap.php';
+            self::$container = require __DIR__ . '/../src/Bootstrap.php';
         }
 
         return self::$container;
@@ -69,9 +70,11 @@ abstract class AbstractTestCase extends TestCase
             new FileStorageMock(),
             $this->getContainer()->get(EntityManager::class),
             $lastPostUpdater,
-            $chainManager
+            $chainManager,
+            $this->getContainer()->get(LoggerInterface::class)
         );
 
-        $importer->import([$thread]);
+        // Do not import images to speed up tests
+        $importer->import([$thread], null, true);
     }
 }

--- a/tests/BoardClient/DvachClientTest.php
+++ b/tests/BoardClient/DvachClientTest.php
@@ -25,7 +25,7 @@ class DvachClientTest extends TestCase
             new Response(200, ['Content-Type' => 'application/json'], FsUtil::getContents(__DIR__ . '/../Fixtures/dvach_api/92.json'))
         );
 
-        $phpThreads = $dvachClient->getAlivePhpThreads();
+        $phpThreads = $dvachClient->getAlivePhpThreads(DvachClient::RETURN_THREADS);
 
         $this->assertCount(3, $phpThreads);
 
@@ -54,7 +54,7 @@ class DvachClientTest extends TestCase
         $dvachApiClient = $this->createDvachApiClient(
             new Response(200, ['Content-Type' => 'application/json'], FsUtil::getContents(__DIR__ . '/../Fixtures/dvach_api/catalog_without_php_threads.json'))
         );
-        $this->assertEmpty($dvachApiClient->getAlivePhpThreads());
+        $this->assertEmpty($dvachApiClient->getAlivePhpThreads(DvachClient::RETURN_THREADS));
     }
 
     private function createDvachApiClient(Response ...$responses): DvachClient

--- a/tests/FileStorage/LocalFileStorageTest.php
+++ b/tests/FileStorage/LocalFileStorageTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\FileStorage;
 
-use org\bovigo\vfs\vfsStream;
-use phpClub\Entity\File;
-use phpClub\FileStorage\LocalFileStorage;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;
 use Tests\AbstractTestCase;
+use org\bovigo\vfs\vfsStream;
+use phpClub\Entity\File;
+use phpClub\FileStorage\LocalFileStorage;
 
 class LocalFileStorageTest extends AbstractTestCase
 {
@@ -18,7 +21,19 @@ class LocalFileStorageTest extends AbstractTestCase
     public function setUp(): void
     {
         $testDirectory = vfsStream::setup();
-        $this->fileStorage = new LocalFileStorage(new Filesystem(), $testDirectory->url());
+        $this->fileStorage = new LocalFileStorage(
+            new Filesystem(), 
+            $this->mockGuzzle(), // Should not be called
+            $testDirectory->url()
+        );
+    }
+
+    private function mockGuzzle(): Client
+    {
+        $mockHandler = new MockHandler([]);
+        $stack = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $stack]);
+        return $client;
     }
 
     public function testFileStorage()

--- a/tests/ThreadImport/ThreadImporterTest.php
+++ b/tests/ThreadImport/ThreadImporterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ThreadImport;
+
+use Doctrine\ORM\EntityManager;
+use Tests\AbstractTestCase;
+
+class ThreadImporterTest extends AbstractTestCase
+{
+    private EntityManager $entityManager;
+
+    public function setUp(): void
+    {
+        $this->entityManager = $this->getContainer()->get(EntityManager::class);
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    public function tearDown(): void
+    {
+        $this->entityManager->getConnection()->rollBack();
+    }
+
+    public function testCanImportTwice(): void 
+    {
+    	$threadHtml = __DIR__ . '/../Fixtures/dvach/80.html';
+    	$this->importThreadToDb($threadHtml);
+    	$this->importThreadToDb($threadHtml);
+    }
+}


### PR DESCRIPTION
Проблема с integrity violation была в том, что у Reflink был внешний ключ, для которого не было указано действие `ON DELETE`. В этом случае MySQL понимает это как `ON DELETE RESTRICT` - не позволять удаление, о чем и писалось сообщение: 

> SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`phpclub`.`ref_link`, CONSTRAINT `FK_21DFD8761645DEA9` FOREIGN KEY (`reference_id`) REFERENCES `post` (`id`))    

То есть, мы пытаемся удалить тред, это вызывает удаление постов в нем, это вызывает удаление ссылающихся на них ref_link и тут и срабатывает RESTRICT. Причем, там у ref_link было 2 ключа, один с `ON DELETE CASCADE`, другой с `RESTRICT` и какой сработает, зависело от удачи и фазы луны.

Также, сделал другие правки: 

- LocalFileSystem теперь явно загружает картинки через Guzzle. Делал это на случай тестов (обнаруживать попытку скачивания картинок, когда это запрещено) или для логгирования, но в итоге никак не использовал.
- добавлены опции `--no-images` (для ускорения при тестировании и отладке), `--dump-urls`, `--download-to` в импорт
- лог в dev теперь пишется еще и в консоль, так варнинги будет проще заметить. Кстати, он должен и при запуске встроенного в PHP сервера писаться в stderr.

Если будет время, просьба потестить и смержить. Phpunit тесты я прогнал, также несколько раз сделал импорт из arhivach/2ch-api.

Также, хотел сделать тест для команды импорта, но тут все сложно: 

- у команды куча зависимостей, проще всего ее брать из контейнера, но у нас нет готового метода для создания временного контейнера с подменой в нем отдельных сервисов. Мы могли бы делать `require Bootstrap.php`, но он при каждом вызове ставит новый обработчик ошибок.

Идея была такая: подменяем Guzzle в контейнере на стаб и кормим команду файлами вместо реальных запросов. В идеале, делаем для нее специальный микротред из нескольких постов, чтобы она не пыталась в тесте импортировать все 900 постов. Тестировать там можно много чего: 

- что команда успешно импортирует треды
- что команда успешно обновляет треды
- что опция --no-images работает и не грузит изображения (для этого в LFS и был засунут Guzzle)
- что другие опции работают, как требуется
- что рефлинки создаются 
- итд.

Если у кого-то вдруг когда-нибудь появится свободное время и желание потестировать CLI команды - можно этим заняться. Команду хорошо бы тестировать, так как она довольно сложная и в ней полно всякой логики.
